### PR TITLE
program: Always distribute full amount

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -26,9 +26,6 @@ struct RewardDistribution {
 // * 40% to all token stakers.
 // * 50% to all token holders.
 fn calculate_distribution(amount: u64) -> Result<RewardDistribution, ProgramError> {
-    let treasury_reward = amount
-        .checked_div(10)
-        .ok_or(ProgramError::InvalidInstructionData)?;
     let stakers_reward = amount
         .checked_mul(2)
         .and_then(|v| v.checked_div(5))
@@ -36,6 +33,11 @@ fn calculate_distribution(amount: u64) -> Result<RewardDistribution, ProgramErro
     let holders_reward = amount
         .checked_div(2)
         .ok_or(ProgramError::InvalidInstructionData)?;
+    let treasury_reward = amount
+        .checked_sub(holders_reward)
+        .unwrap()
+        .checked_sub(stakers_reward)
+        .unwrap();
 
     Ok(RewardDistribution {
         treasury_reward,


### PR DESCRIPTION
#### Problem

Due to truncation during division, it's often possible to not distribute the full `amount` provided to the instruction.

#### Solution

To get around that, we allow the treasury to get all of the lamports truncated during reward calculation. That seemed like the fairest option, since otherwise someone could call the distribution with just 1 lamport to screw over the holders or the stakers.